### PR TITLE
Improve error logging and defaults

### DIFF
--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -1,12 +1,14 @@
-from typing import Optional, Dict, Any
+from typing import Any
 from uuid import UUID
+
 from app.services.database import DatabaseService
+
 
 async def get_or_create_profile(
     user_id: UUID, 
-    display_name: Optional[str] = None,
-    database: DatabaseService = None
-) -> Dict[str, Any]:
+    display_name: str | None = None,
+    database: DatabaseService | None = None
+) -> dict[str, Any]:
     """Get or create a user profile."""
     if database is None:
         database = DatabaseService()
@@ -15,11 +17,11 @@ async def get_or_create_profile(
 
 async def update_profile(
     user_id: UUID,
-    display_name: Optional[str] = None,
-    avatar_url: Optional[str] = None,
-    default_venue: Optional[UUID] = None,
-    database: DatabaseService = None
-) -> Dict[str, Any]:
+    display_name: str | None = None,
+    avatar_url: str | None = None,
+    default_venue: UUID | None = None,
+    database: DatabaseService | None = None
+) -> dict[str, Any]:
     """Update user profile information."""
     if database is None:
         database = DatabaseService()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,7 @@
-from typing import Optional, List
-from pydantic_settings import BaseSettings
-from pydantic import PostgresDsn, field_validator, ConfigDict, ValidationInfo
+
 from dotenv import load_dotenv
+from pydantic import ConfigDict, PostgresDsn, ValidationInfo, field_validator
+from pydantic_settings import BaseSettings
 
 load_dotenv()
 
@@ -29,18 +29,22 @@ class Settings(BaseSettings):
     DEBUG: bool = True
     
     # CORS
-    BACKEND_CORS_ORIGINS: List[str] = ["http://localhost:3000", "http://localhost:8000", "http://localhost:8080"]
+    BACKEND_CORS_ORIGINS: list[str] = [
+        "http://localhost:3000",
+        "http://localhost:8000",
+        "http://localhost:8080",
+    ]
     
     # Logging
     LOG_LEVEL: str = "INFO"
 
     # Generated URL
-    LOCAL_DATABASE_URL: Optional[PostgresDsn] = None
-    REMOTE_DATABASE_URL: Optional[PostgresDsn] = None
+    LOCAL_DATABASE_URL: PostgresDsn | None = None
+    REMOTE_DATABASE_URL: PostgresDsn | None = None
 
     @field_validator("LOCAL_DATABASE_URL", mode="before")
     @classmethod
-    def assemble_local_db_url(cls, v: Optional[str], info: ValidationInfo):
+    def assemble_local_db_url(cls, v: str | None, info: ValidationInfo):
         if isinstance(v, str):
             return v
         return PostgresDsn.build(
@@ -54,7 +58,7 @@ class Settings(BaseSettings):
 
     @field_validator("REMOTE_DATABASE_URL", mode="before")
     @classmethod
-    def assemble_remote_db_url(cls, v: Optional[str], info: ValidationInfo):
+    def assemble_remote_db_url(cls, v: str | None, info: ValidationInfo):
         if isinstance(v, str):
             return v
         return PostgresDsn.build(
@@ -72,3 +76,4 @@ class Settings(BaseSettings):
     )
 
 settings = Settings() 
+

--- a/app/core/matches.py
+++ b/app/core/matches.py
@@ -1,18 +1,21 @@
 from datetime import datetime
-from typing import List, Dict, Tuple, Any
+from typing import Any
 from uuid import UUID
-from app.services.database import DatabaseService
+
 from trueskill import Rating, rate
+
+from app.services.database import DatabaseService
+
 
 async def create_match(
     venue_id: UUID,
     created_by: UUID,
-    team1_players: Tuple[UUID, UUID],
-    team2_players: Tuple[UUID, UUID],
-    scores: List[Dict[str, int]],
+    team1_players: tuple[UUID, UUID],
+    team2_players: tuple[UUID, UUID],
+    scores: list[dict[str, int]],
     played_at: datetime,
     database: DatabaseService = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create a new match and update ratings."""
 
     if database is None:
@@ -43,8 +46,11 @@ async def create_match(
     
     return match
 
-async def update_ratings(match_id: UUID, database: DatabaseService = DatabaseService()) -> None:
+async def update_ratings(match_id: UUID, database: DatabaseService | None = None) -> None:
     """Update TrueSkill ratings after a match."""
+    if database is None:
+        database = DatabaseService()
+
     match = await database.get_match(match_id)
     if not match:
         return
@@ -78,7 +84,7 @@ async def update_ratings(match_id: UUID, database: DatabaseService = DatabaseSer
         new_team2_ratings, new_team1_ratings = rate([team2_ratings, team1_ratings])
     
     # Update individual ratings
-    for player, new_rating in zip(team1_players, new_team1_ratings):
+    for player, new_rating in zip(team1_players, new_team1_ratings, strict=False):
         # Get current games_played from existing rating
         current_rating = await database.get_player_rating(UUID(player["player_id"]))
         current_games_played = current_rating.get("games_played", 0) if current_rating else 0
@@ -90,7 +96,7 @@ async def update_ratings(match_id: UUID, database: DatabaseService = DatabaseSer
             current_games_played + 1
         )
     
-    for player, new_rating in zip(team2_players, new_team2_ratings):
+    for player, new_rating in zip(team2_players, new_team2_ratings, strict=False):
         # Get current games_played from existing rating
         current_rating = await database.get_player_rating(UUID(player["player_id"]))
         current_games_played = current_rating.get("games_played", 0) if current_rating else 0
@@ -117,14 +123,29 @@ async def update_ratings(match_id: UUID, database: DatabaseService = DatabaseSer
         new_team2_ratings[0].sigma
     )
 
-async def get_player_matches(player_id: UUID, database: DatabaseService = DatabaseService()) -> List[Dict[str, Any]]:
+async def get_player_matches(
+    player_id: UUID, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get all matches a player participated in."""
+    if database is None:
+        database = DatabaseService()
+
     return await database.get_player_matches(player_id)
 
-async def get_venue_matches(venue_id: UUID, database: DatabaseService = DatabaseService()) -> List[Dict[str, Any]]:
+async def get_venue_matches(
+    venue_id: UUID, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get all matches at a venue."""
+    if database is None:
+        database = DatabaseService()
+
     return await database.get_venue_matches(venue_id)
 
-async def get_top_players(limit: int = 10, database: DatabaseService = DatabaseService()) -> List[Dict[str, Any]]:
+async def get_top_players(
+    limit: int = 10, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get top players by rating."""
-    return await database.get_top_players(limit) 
+    if database is None:
+        database = DatabaseService()
+
+    return await database.get_top_players(limit)

--- a/app/core/social.py
+++ b/app/core/social.py
@@ -1,21 +1,30 @@
-from typing import List, Dict, Any
+import logging
+from typing import Any
 from uuid import UUID
-import traceback
+
 from app.services.database import DatabaseService
 
-async def follow_player(follower_id: UUID, followee_id: UUID, database: DatabaseService = None) -> Dict[str, Any]:
+logger = logging.getLogger(__name__)
+
+async def follow_player(
+    follower_id: UUID, followee_id: UUID, database: DatabaseService | None = None
+) -> dict[str, Any]:
     """Follow another player."""
     if database is None:
         database = DatabaseService()
     return await database.follow_user(follower_id, followee_id)
 
-async def unfollow_player(follower_id: UUID, followee_id: UUID, database: DatabaseService = None) -> None:
+async def unfollow_player(
+    follower_id: UUID, followee_id: UUID, database: DatabaseService | None = None
+) -> None:
     """Unfollow another player."""
     if database is None:
         database = DatabaseService()
     await database.unfollow_user(follower_id, followee_id)
 
-async def get_followers(user_id: UUID, database: DatabaseService = None) -> List[Dict[str, Any]]:
+async def get_followers(
+    user_id: UUID, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get all followers of a user with their profiles."""
     if database is None:
         database = DatabaseService()
@@ -27,18 +36,18 @@ async def get_followers(user_id: UUID, database: DatabaseService = None) -> List
         try:
             profile = await database.get_profile(UUID(follower["follower"]))
             profiles.append(profile)
-        except Exception as e:
-            # Print traceback and related info
-            print(f"Error getting profile for follower {follower['follower']} of user {user_id}:")
-            print(f"Exception: {type(e).__name__}: {e}")
-            print(f"Traceback:")
-            traceback.print_exc()
+        except Exception:
+            logger.exception(
+                "Error getting profile for follower %s of user %s", follower["follower"], user_id
+            )
             # Skip if profile doesn't exist
             continue
     
     return profiles
 
-async def get_following(user_id: UUID, database: DatabaseService = None) -> List[Dict[str, Any]]:
+async def get_following(
+    user_id: UUID, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get all users that a user is following with their profiles."""
     if database is None:
         database = DatabaseService()
@@ -50,18 +59,18 @@ async def get_following(user_id: UUID, database: DatabaseService = None) -> List
         try:
             profile = await database.get_profile(UUID(followee["followee"]))
             profiles.append(profile)
-        except Exception as e:
-            # Print traceback and related info
-            print(f"Error getting profile for followee {followee['followee']} followed by user {user_id}:")
-            print(f"Exception: {type(e).__name__}: {e}")
-            print(f"Traceback:")
-            traceback.print_exc()
+        except Exception:
+            logger.exception(
+                "Error getting profile for followee %s followed by user %s", followee["followee"], user_id
+            )
             # Skip if profile doesn't exist
             continue
     
     return profiles
 
-async def get_mutual_followers(user_id: UUID, database: DatabaseService = None) -> List[Dict[str, Any]]:
+async def get_mutual_followers(
+    user_id: UUID, database: DatabaseService | None = None
+) -> list[dict[str, Any]]:
     """Get mutual followers (users who follow each other) with their profiles."""
     if database is None:
         database = DatabaseService()
@@ -73,12 +82,10 @@ async def get_mutual_followers(user_id: UUID, database: DatabaseService = None) 
         try:
             profile = await database.get_profile(UUID(mutual["user_id"]))
             profiles.append(profile)
-        except Exception as e:
-            # Print traceback and related info
-            print(f"Error getting profile for mutual follower {mutual['user_id']} of user {user_id}:")
-            print(f"Exception: {type(e).__name__}: {e}")
-            print(f"Traceback:")
-            traceback.print_exc()
+        except Exception:
+            logger.exception(
+                "Error getting profile for mutual follower %s of user %s", mutual["user_id"], user_id
+            )
             # Skip if profile doesn't exist
             continue
     

--- a/app/core/venues.py
+++ b/app/core/venues.py
@@ -1,16 +1,19 @@
-from typing import List, Optional, Dict, Any
+import logging
+from typing import Any
 from uuid import UUID
-import traceback
+
 from app.services.database import DatabaseService
+
+logger = logging.getLogger(__name__)
 
 async def create_venue(
     name: str,
     latitude: float,
     longitude: float,
-    address: Optional[str],
+    address: str | None,
     created_by: UUID,
     database: DatabaseService = None
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Create a new venue."""
     if database is None:
         database = DatabaseService()
@@ -28,14 +31,16 @@ async def find_nearby_venues(
     longitude: float,
     radius_meters: float = 5000,
     database: DatabaseService = None
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Find venues within a certain radius."""
     if database is None:
         database = DatabaseService()
     
     return await database.find_nearby_venues(latitude, longitude, radius_meters)
 
-async def get_venue(venue_id: UUID, database: DatabaseService = None) -> Optional[Dict[str, Any]]:
+async def get_venue(
+    venue_id: UUID, database: DatabaseService | None = None
+) -> dict[str, Any] | None:
     """Get venue by ID."""
     if database is None:
         database = DatabaseService()
@@ -43,18 +48,17 @@ async def get_venue(venue_id: UUID, database: DatabaseService = None) -> Optiona
     try:
         return await database.get_venue(venue_id)
     except Exception as e:
-        print(f"Error getting venue {venue_id}: {str(e)}")
-        traceback.print_exc()
+        logger.exception("Error getting venue %s: %s", venue_id, e)
         return None
 
 async def update_venue(
     venue_id: UUID,
-    name: Optional[str] = None,
-    latitude: Optional[float] = None,
-    longitude: Optional[float] = None,
-    address: Optional[str] = None,
-    database: DatabaseService = None
-) -> Optional[Dict[str, Any]]:
+    name: str | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
+    address: str | None = None,
+    database: DatabaseService | None = None,
+) -> dict[str, Any] | None:
     """Update venue information."""
     if database is None:
         database = DatabaseService()
@@ -74,6 +78,5 @@ async def update_venue(
     try:
         return await database.update_venue(venue_id, update_data)
     except Exception as e:
-        print(f"Error updating venue {venue_id}: {str(e)}")
-        traceback.print_exc()
-        return None 
+        logger.exception("Error updating venue %s: %s", venue_id, e)
+        return None


### PR DESCRIPTION
## Summary
- replace print debugging with standard logging in social and venue logic
- fix DatabaseService creation defaults in match helpers
- modernize type hints and organize imports
- split long `BACKEND_CORS_ORIGINS` for readability

## Testing
- `ruff check app/core/auth.py app/core/config.py app/core/matches.py app/core/social.py app/core/venues.py`
- `pytest -q` *(fails: ImportError: cannot import name 'create_client' from 'supabase')*

------
https://chatgpt.com/codex/tasks/task_e_684535f6d27883309a05db8eefba0549