### PR TITLE
Add frontend cursor rules

### DIFF
--- a/.cursor/rules/101-frontend-overview.mdc
+++ b/.cursor/rules/101-frontend-overview.mdc
@@ -1,0 +1,42 @@
+---
+description: Frontend project overview and design/coding principles
+globs:
+  - frontend/**
+alwaysApply: false
+---
+# Smash Mate Frontend – Overview & Guidelines
+
+## Purpose
+This repo contains the React Native + Expo mobile application for Smash Mate. The app allows users to sign in, select venues, record matches, view leaderboards and message other players. It consumes the FastAPI backend described in the backend rules.
+
+## Core Tech Stack
+- **React Native** with **Expo**
+- **TypeScript** for static typing
+- **React Navigation** for screen routing
+- **React Query (TanStack Query)** for data fetching & caching
+- **Supabase JS** for authentication and realtime features
+- **NativeWind** (Tailwind CSS for RN) for styling
+
+## UI Design Principles
+1. **Modern & Minimal** – Clean layouts, ample white space, consistent spacing.
+2. **Fancy but Simple** – Use smooth animations and gradients sparingly to enhance appeal without clutter.
+3. **Accessibility** – Proper contrast ratios and scalable fonts.
+4. **Consistent Components** – Build reusable components in `frontend/components/`.
+5. **Dark Mode** – Support both light and dark themes using a central theme file.
+
+## Coding Style
+- Use ESLint with Airbnb/React Native rules.
+- Prettier for formatting (tabs=2, single quotes, semicolons).
+- All files are TypeScript (`.tsx` for components, `.ts` otherwise).
+- Keep screens in `frontend/screens/` and hooks in `frontend/hooks/`.
+- Favor functional components and React hooks.
+- State management via React Query and React Context; avoid Redux unless needed.
+
+## Quick Start
+```bash
+# Install dependencies
+npm install -g expo-cli
+npm install
+# Start the development server
+expo start
+```

--- a/.cursor/rules/102-frontend-file-structure.mdc
+++ b/.cursor/rules/102-frontend-file-structure.mdc
@@ -1,0 +1,28 @@
+---
+description: File structure for the Smash Mate frontend repo
+globs:
+  - frontend/**
+alwaysApply: false
+---
+# File Structure Guidelines
+
+All frontend code lives under the `frontend/` directory at the repository root.
+
+```
+frontend/
+├── App.tsx              # Expo entry point
+├── app.config.ts        # Expo configuration
+├── components/          # Reusable UI components
+├── screens/             # Screen components for navigation
+├── navigation/          # React Navigation setup
+├── hooks/               # Custom React hooks
+├── lib/                 # API clients and shared utilities
+├── assets/              # Images, fonts, and static assets
+├── theme/               # Light/Dark theme definitions
+├── tests/               # Jest test files
+└── package.json         # Node dependencies
+```
+
+Place each screen in its own subfolder inside `screens/` with an `index.tsx` file and related styles. Components that are used across multiple screens go in `components/`.
+
+Keep API interaction functions in `lib/api.ts` and data-fetching hooks in `hooks/use*.ts`.

--- a/.cursor/rules/103-frontend-api.mdc
+++ b/.cursor/rules/103-frontend-api.mdc
@@ -1,0 +1,35 @@
+---
+description: Backend API endpoints consumed by the frontend
+globs:
+  - frontend/**
+alwaysApply: false
+---
+# Backend API Reference
+
+The frontend communicates with the FastAPI backend at `${BACKEND_URL}/api/v1`.
+Only a subset of endpoints are used initially:
+
+## Auth
+- `GET /auth/profile/{user_id}` – Fetch or create the signed-in user's profile.
+- `PUT /auth/profile/{user_id}` – Update profile data.
+
+## Venues
+- `GET /venues/nearby?latitude=&longitude=&radius_meters=` – Search nearby venues.
+- `POST /venues/?created_by=` – Create a new venue.
+
+## Matches
+- `POST /matches/?created_by=` – Submit a new match.
+- `GET /matches/player/{player_id}` – List player's match history.
+- `GET /matches/leaderboard?limit=` – Get top rated players.
+
+## Social
+- `POST /social/follow/{user_id}` – Follow another player.
+- `GET /social/followers/{user_id}` – List user's followers.
+
+## Messaging
+- `POST /messages/` – Send a direct message.
+- `GET /messages/{user_id}` – Fetch user's direct messages.
+
+All endpoints return JSON encoded responses matching the Pydantic schemas from the backend rules. Authentication is handled via Supabase JWT tokens passed in the `Authorization` header (`Bearer <token>`).
+
+Refer to Swagger docs at `${BACKEND_URL}/api/v1/docs` for details.

--- a/.cursor/rules/104-frontend-tests.mdc
+++ b/.cursor/rules/104-frontend-tests.mdc
@@ -1,0 +1,32 @@
+---
+description: Testing strategy for the frontend
+globs:
+  - frontend/**
+alwaysApply: false
+---
+# Testing Rules
+
+## Tools
+- **Jest** with **@testing-library/react-native** for component tests.
+- **Expo E2E** tests using **Jest + Detox** for integration flows.
+- **msw** (Mock Service Worker) for mocking backend requests during tests.
+
+## Unit Tests
+1. Place test files next to the component under `__tests__/` using `*.test.tsx` or `*.test.ts`.
+2. Test component rendering, props, and interactions with React Native Testing Library.
+3. Mock external modules and API calls using `jest.mock` or MSW handlers.
+
+## Integration Tests
+1. Detox tests live in `frontend/tests/e2e/`.
+2. Use Expo's managed workflow with `detox-expo-helpers` to start the app.
+3. Simulate typical user flows (login, record match, view leaderboard).
+4. Keep tests deterministic by seeding the backend or mocking API responses via MSW.
+
+## Running Tests
+```bash
+# Run unit tests
+npm test
+
+# Run Detox integration tests (requires iOS/Android simulator)
+npm run e2e
+```


### PR DESCRIPTION
## Summary
- add frontend overview rules
- document recommended file structure
- list backend APIs used by the frontend
- outline unit and integration test strategy

## Testing
- `pytest -q` *(fails: ImportError supabase)*

------
https://chatgpt.com/codex/tasks/task_e_684786c19a4c8330ac4750faff6851ae