### PR TITLE
Add players table for fake player linking

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,1 +1,2 @@
 # API routes package
+from . import auth, matches, players, recommendations, social, venues  # noqa: F401

--- a/app/api/players.py
+++ b/app/api/players.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core import players as players_core
+from app.core.dependencies import get_database_service
+from app.services.database import DatabaseService
+
+router = APIRouter(prefix="/players", tags=["players"])
+
+
+@router.post("/fake")
+async def create_fake_player(
+    owner_id: UUID,
+    display_name: str,
+    database: DatabaseService = Depends(get_database_service),
+):
+    """Create a fake player profile."""
+    try:
+        player = await players_core.create_fake_player(
+            owner_id=owner_id,
+            display_name=display_name,
+            database=database,
+        )
+        return player
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post("/{fake_id}/link/{real_id}")
+async def link_fake_player(
+    fake_id: UUID,
+    real_id: UUID,
+    database: DatabaseService = Depends(get_database_service),
+):
+    """Link a fake player to an existing player."""
+    try:
+        player = await players_core.link_fake_player(
+            fake_id=fake_id,
+            real_player_id=real_id,
+            database=database,
+        )
+        return player
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e

--- a/app/core/players.py
+++ b/app/core/players.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Any
+from uuid import UUID
+
+from app.services.database import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+
+async def create_fake_player(
+    owner_id: UUID,
+    display_name: str,
+    database: DatabaseService | None = None,
+) -> dict[str, Any]:
+    """Create a fake player owned by a user."""
+    if database is None:
+        database = DatabaseService()
+
+    return await database.create_fake_player(owner_id, display_name)
+
+
+async def link_fake_player(
+    fake_id: UUID,
+    real_player_id: UUID,
+    database: DatabaseService | None = None,
+) -> dict[str, Any]:
+    """Link a fake player to a real player."""
+    if database is None:
+        database = DatabaseService()
+
+    return await database.link_fake_to_real(fake_id, real_player_id)

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api import auth, matches, players, recommendations, social, venues
 from app.core.config import settings
-from app.api import auth, matches, venues, social, recommendations
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
@@ -27,10 +27,13 @@ app.include_router(matches.router, prefix=settings.API_V1_STR)
 app.include_router(venues.router, prefix=settings.API_V1_STR)
 app.include_router(social.router, prefix=settings.API_V1_STR)
 app.include_router(recommendations.router, prefix=settings.API_V1_STR)
+app.include_router(players.router, prefix=settings.API_V1_STR)
+
 
 @app.get("/")
 async def root():
     return {"message": "Welcome to SmashMate API"}
+
 
 @app.get("/health")
 async def health_check():

--- a/docs/fake_player_plan.md
+++ b/docs/fake_player_plan.md
@@ -1,0 +1,17 @@
+# Fake Player Linking Refactor
+
+This migration introduces a unified `players` table to store both real users and fake players. Fake players can be linked to real players so their match history and ratings merge.
+
+## Database Changes
+
+- New `players` table with columns:
+  - `id` primary key
+  - `user_id` references `auth.users` (null for fake players)
+  - `owner_id` the user who created the fake player
+  - `display_name`
+  - `linked_player` optional reference to another player
+- Existing tables `teams`, `player_ratings` and `match_players` now reference `players.id` instead of `auth.users`.
+- A data migration seeds rows for all existing users so their player IDs match their user IDs.
+- Row level security policies restrict access so users can manage their own fake players.
+
+Run `supabase db push` after applying the migration file `20240401000000_add_players.sql`.

--- a/supabase/migrations/20240401000000_add_players.sql
+++ b/supabase/migrations/20240401000000_add_players.sql
@@ -1,0 +1,52 @@
+-- Add players table for real and fake player profiles
+create table players (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid unique references auth.users,
+  owner_id uuid references auth.users not null,
+  display_name text not null,
+  linked_player uuid references players(id),
+  created_at timestamptz default now()
+);
+
+-- Seed players table with existing users
+insert into players (id, user_id, owner_id, display_name)
+select u.id, u.id, u.id, coalesce(p.display_name, '')
+from auth.users u
+left join profiles p on p.user_id = u.id;
+
+-- Update foreign keys to reference players
+alter table teams drop constraint if exists teams_player_a_fkey;
+alter table teams drop constraint if exists teams_player_b_fkey;
+alter table teams add constraint teams_player_a_fkey foreign key (player_a) references players(id);
+alter table teams add constraint teams_player_b_fkey foreign key (player_b) references players(id);
+
+alter table player_ratings drop constraint if exists player_ratings_player_id_fkey;
+alter table player_ratings add constraint player_ratings_player_id_fkey foreign key (player_id) references players(id);
+
+alter table match_players drop constraint if exists match_players_player_id_fkey;
+alter table match_players add constraint match_players_player_id_fkey foreign key (player_id) references players(id);
+
+-- Recreate compatibility view to join players
+drop materialized view if exists compatibility;
+create materialized view compatibility as
+select
+  t.player_a,
+  t.player_b,
+  t.mu                                    as team_mu,
+  ((r1.mu + r2.mu)/2)                     as avg_individual_mu,
+  t.mu - ((r1.mu + r2.mu)/2)              as delta
+from teams t
+join player_ratings r1 on r1.player_id = t.player_a
+join player_ratings r2 on r2.player_id = t.player_b
+join players p1 on p1.id = t.player_a
+join players p2 on p2.id = t.player_b;
+create unique index on compatibility(player_a, player_b);
+
+-- Row level security for players
+alter table players enable row level security;
+create policy "own players" on players
+  for select using (owner_id = auth.uid() or user_id = auth.uid());
+create policy "insert own players" on players
+  for insert with check (owner_id = auth.uid());
+create policy "update own players" on players
+  for update using (owner_id = auth.uid());


### PR DESCRIPTION
## Summary
- create `players` table migration
- add fake player plan docs
- support players in `DatabaseService`
- add API endpoints and core functions for managing fake players

## Testing
- `ruff check .` *(fails: many style violations)*
- `black --check .` *(fails: would reformat many files)*
- `pytest -q` *(fails: ImportError: cannot import name 'create_client')*

------
https://chatgpt.com/codex/tasks/task_e_68570c61bdac8330b3fa58f3c839ab4e